### PR TITLE
Adding support to switch back and forth between serverless instances

### DIFF
--- a/src/cluster.tf
+++ b/src/cluster.tf
@@ -42,7 +42,7 @@ resource "aws_rds_cluster" "main" {
   # This sets the serverless values no matter what, defaulting to minimums. The instance type
   #   still controls whether its serverless or not.
   serverlessv2_scaling_configuration {
-    min_capacity = local.effective_serverless_scaling.min_capacity
-    max_capacity = local.effective_serverless_scaling.max_capacity
+    min_capacity = local.serverless_scaling.min_capacity
+    max_capacity = local.serverless_scaling.max_capacity
   }
 }

--- a/src/cluster.tf
+++ b/src/cluster.tf
@@ -42,7 +42,7 @@ resource "aws_rds_cluster" "main" {
   # This sets the serverless values no matter what, defaulting to minimums. The instance type
   #   still controls whether its serverless or not.
   serverlessv2_scaling_configuration {
-    min_capacity = lookup(var.database.serverless_scaling, "min_capacity", 0.5)
-    max_capacity = lookup(var.database.serverless_scaling, "max_capacity", 1.0)
+    min_capacity = local.effective_serverless_scaling.min_capacity
+    max_capacity = local.effective_serverless_scaling.max_capacity
   }
 }

--- a/src/locals.tf
+++ b/src/locals.tf
@@ -19,15 +19,10 @@ locals {
   enhanced_monitoring_enabled           = lookup(var.observability, "enhanced_monitoring_interval", 0) > 0
   autoscaling_enabled                   = var.availability.autoscaling_mode != "DISABLED"
 
-  default_serverless_scaling = {
+  serverless_scaling = lookup(var.database, "serverless_scaling", {
     min_capacity = 0.5
     max_capacity = 1.0
-  }
-
-  effective_serverless_scaling = merge(
-    local.default_serverless_scaling,
-    var.database.serverless_scaling != null ? var.database.serverless_scaling : {}
-  )
+  })
 
   # Primary + Replicas
   # We don't differentiate the primary as a terraform resource in the event that their is a failover

--- a/src/locals.tf
+++ b/src/locals.tf
@@ -19,6 +19,16 @@ locals {
   enhanced_monitoring_enabled           = lookup(var.observability, "enhanced_monitoring_interval", 0) > 0
   autoscaling_enabled                   = var.availability.autoscaling_mode != "DISABLED"
 
+  default_serverless_scaling = {
+    min_capacity = 0.5
+    max_capacity = 1.0
+  }
+
+  effective_serverless_scaling = merge(
+    local.default_serverless_scaling,
+    var.database.serverless_scaling != null ? var.database.serverless_scaling : {}
+  )
+
   # Primary + Replicas
   # We don't differentiate the primary as a terraform resource in the event that their is a failover
   # AWS will promote a replica. By not differentiating the naming/tf resource we avoid


### PR DESCRIPTION
This support already existed, but could give a nonsensical error in some cases saying that ACU min/max is required to _not_ use serverless. Yay.