### PR TITLE
Fix for instance type switching on older pg versions

### DIFF
--- a/src/cluster.tf
+++ b/src/cluster.tf
@@ -35,14 +35,11 @@ resource "aws_rds_cluster" "main" {
   # db_cluster_parameter_group_name - (Optional) A cluster parameter group to associate with the cluster.
   # db_instance_parameter_group_name - (Optional) Instance parameter group to associate with all instances of the DB cluster. The db_instance_parameter_group_name parameter is only valid in combination with the allow_major_version_upgrade parameter.
 
-  # This originally used a dynamic block to set the scaling or exclude the block if not instance type serverless,
-  #   but when switching instance types terraform would get confused still requiring min_capacity & max_capacity even though
-  #   it was no longer "serverless"
-  #
-  # This sets the serverless values no matter what, defaulting to minimums. The instance type
-  #   still controls whether its serverless or not.
-  serverlessv2_scaling_configuration {
-    min_capacity = local.serverless_scaling.min_capacity
-    max_capacity = local.serverless_scaling.max_capacity
+  dynamic "serverlessv2_scaling_configuration" {
+    for_each = local.is_serverless ? [1] : []
+    content {
+      min_capacity = local.serverless_scaling.min_capacity
+      max_capacity = local.serverless_scaling.max_capacity
+    }
   }
 }


### PR DESCRIPTION
AWS and/or Terraform have some interesting logic on the svls v2 config.

This change + the existing local's defaults make it possible to switch instance types from serverless to serverful (:P) - this worked previously, but not on older versions of postgres that didnt support serverless, they would fail to provision due to a check for the serverless config block (which happens to be present).